### PR TITLE
fix "lain run web cmd 参数解析出错"

### DIFF
--- a/lain_sdk/mydocker.py
+++ b/lain_sdk/mydocker.py
@@ -219,8 +219,6 @@ def proc_run(container_name, image, working_dir, port, cmd, envs, volumes):
         ['-v', '{}:{}'.format(k, v)]
         for k, v in volumes.iteritems()
     ], [])
-    # docker_args = ['run', '-d', '--name={}'.format(container_name)] \
-    #     + working_dir_opt + port_opt + env_opt + volume_opt + [image] + [cmd]
     docker_args = ['run', '-d', '--name={}'.format(container_name)] \
         + working_dir_opt + port_opt + env_opt + volume_opt + [image] + cmd
     _docker(docker_args)

--- a/lain_sdk/mydocker.py
+++ b/lain_sdk/mydocker.py
@@ -39,9 +39,7 @@ def _docker(args, cwd=None, env={}, capture_output=False, print_stdout=True):
     """
 
     cmd = ['docker'] + args
-    info("kai >>> cmd >>> {}".format(cmd))
     env = dict(env, DOCKER_HOST='')
-    info("kai >>> env >>> {}".format(env))
 
     if capture_output:
         try:
@@ -115,8 +113,6 @@ def build(name, context, ignore, template, params):
     dockerfile_path = os.path.join(context, 'Dockerfile')
     dockerignore_path = os.path.join(context, '.dockerignore')
     dockerignore_backup = os.path.join(context, '.dockerignore.backup')
-    info("kai >>> dockerfile_path >>> {}".format(dockerfile_path))
-    info("kai >>> template >>> {}".format(template))
     try:
         gen_dockerfile(dockerfile_path, template, params)
         gen_dockerignore(dockerignore_path, ignore)
@@ -157,20 +153,16 @@ def copy_to_host(image_name, docker_path, host_path, directory=False):
         cp = ['cp', '-r']
     else:
         cp = ['cp']
-    info("kai >>> cp >>> {}".format(cp))
     inter_host_dir = tempfile.mkdtemp()
     inter_dock_dir = '/lain_share'
     docker_args = ['run', '--rm', '-v', '{}:{}'.format(inter_host_dir, inter_dock_dir), image_name]
     docker_args += cp + [docker_path, inter_dock_dir]
-    info("kai >>> before >>> _docker")
-    info("kai >>> docker_args >>> {}".format(docker_args))
     try:
         _docker(docker_args)
     except subprocess.CalledProcessError as e:
         error(e.output)
         exit(1)
 
-    info("kai >>> after >>> _docker")
     inter_host_path = os.path.join(inter_host_dir, os.path.basename(docker_path))
     try:
         shutil.copy(inter_host_path, host_path)

--- a/lain_sdk/mydocker.py
+++ b/lain_sdk/mydocker.py
@@ -219,8 +219,10 @@ def proc_run(container_name, image, working_dir, port, cmd, envs, volumes):
         ['-v', '{}:{}'.format(k, v)]
         for k, v in volumes.iteritems()
     ], [])
+    # docker_args = ['run', '-d', '--name={}'.format(container_name)] \
+    #     + working_dir_opt + port_opt + env_opt + volume_opt + [image] + [cmd]
     docker_args = ['run', '-d', '--name={}'.format(container_name)] \
-        + working_dir_opt + port_opt + env_opt + volume_opt + [image] + [cmd]
+        + working_dir_opt + port_opt + env_opt + volume_opt + [image] + cmd
     _docker(docker_args)
 
 

--- a/lain_sdk/mydocker.py
+++ b/lain_sdk/mydocker.py
@@ -154,6 +154,7 @@ def copy_to_host(image_name, docker_path, host_path, directory=False):
     else:
         cp = ['cp']
     inter_host_dir = tempfile.mkdtemp()
+    info("kai >>> after mkdtemp")
     inter_dock_dir = '/lain_share'
     docker_args = ['run', '--rm', '-v', '{}:{}'.format(inter_host_dir, inter_dock_dir), image_name]
     docker_args += cp + [docker_path, inter_dock_dir]

--- a/lain_sdk/mydocker.py
+++ b/lain_sdk/mydocker.py
@@ -39,7 +39,9 @@ def _docker(args, cwd=None, env={}, capture_output=False, print_stdout=True):
     """
 
     cmd = ['docker'] + args
+    info("kai >>> cmd >>> {}".format(cmd))
     env = dict(env, DOCKER_HOST='')
+    info("kai >>> env >>> {}".format(env))
 
     if capture_output:
         try:
@@ -113,6 +115,8 @@ def build(name, context, ignore, template, params):
     dockerfile_path = os.path.join(context, 'Dockerfile')
     dockerignore_path = os.path.join(context, '.dockerignore')
     dockerignore_backup = os.path.join(context, '.dockerignore.backup')
+    info("kai >>> dockerfile_path >>> {}".format(dockerfile_path))
+    info("kai >>> template >>> {}".format(template))
     try:
         gen_dockerfile(dockerfile_path, template, params)
         gen_dockerignore(dockerignore_path, ignore)
@@ -153,17 +157,20 @@ def copy_to_host(image_name, docker_path, host_path, directory=False):
         cp = ['cp', '-r']
     else:
         cp = ['cp']
+    info("kai >>> cp >>> {}".format(cp))
     inter_host_dir = tempfile.mkdtemp()
-    info("kai >>> after mkdtemp")
     inter_dock_dir = '/lain_share'
     docker_args = ['run', '--rm', '-v', '{}:{}'.format(inter_host_dir, inter_dock_dir), image_name]
     docker_args += cp + [docker_path, inter_dock_dir]
+    info("kai >>> before >>> _docker")
+    info("kai >>> docker_args >>> {}".format(docker_args))
     try:
         _docker(docker_args)
     except subprocess.CalledProcessError as e:
         error(e.output)
         exit(1)
 
+    info("kai >>> after >>> _docker")
     inter_host_path = os.path.join(inter_host_dir, os.path.basename(docker_path))
     try:
         shutil.copy(inter_host_path, host_path)

--- a/lain_sdk/yaml/parser.py
+++ b/lain_sdk/yaml/parser.py
@@ -171,7 +171,9 @@ class Proc:
         self.image = meta.get('image', default_image_name)
         meta_cmd = meta.get('cmd')
         info("kai >>> meta_cmd: {}".format(meta_cmd))
-        self.cmd = meta_cmd if meta_cmd else ''
+        # self.cmd = meta_cmd if meta_cmd else ''
+        self.cmd = self.__to_cmd_list(meta_cmd)
+        info("kai >>> self.cmd: {}".format(self.cmd))
         self.user = meta.get('user', '')
         self.working_dir = meta.get('workdir') or meta.get('working_dir', '')
         dns_search_meta = meta.get('dns_search', [])
@@ -336,6 +338,15 @@ class Proc:
         # 仅patch此proc的动态scale的meta信息
         for k in self.SIMPLE_SCALE_KEYWORDS._member_names_:
             self.__dict__[k] = proc.__dict__[k]
+
+    def __to_cmd_list(self, meta_cmd):
+        if isinstance(meta_cmd, basestring):
+            cmd_list = meta_cmd.split()
+        elif isinstance(meta_cmd, list) and all(isinstance(item, basestring) for item in meta_cmd):
+            cmd_list = meta_cmd
+        else:   # None 或者非法输入，在 lain validate 里检查
+            cmd_list = []
+        return cmd_list
 
     @property
     def annotation(self):

--- a/lain_sdk/yaml/parser.py
+++ b/lain_sdk/yaml/parser.py
@@ -171,14 +171,9 @@ class Proc:
             self.type = ProcType[proc_info[0]]  ## 放弃meta里面的type定义
         self.image = meta.get('image', default_image_name)
         meta_entrypoint = meta.get('entrypoint')
-        info("kai >>> meta_entrypoint: {}".format(meta_entrypoint))
         self.entrypoint = self.__to_exec_form(meta_entrypoint)
-        info("kai >>> self.entrypoint: {}".format(self.entrypoint))
         meta_cmd = meta.get('cmd')
-        info("kai >>> meta_cmd: {}".format(meta_cmd))
-        # self.cmd = meta_cmd if meta_cmd else ''
         self.cmd = self.__to_exec_form(meta_cmd)
-        info("kai >>> self.cmd: {}".format(self.cmd))
         self.user = meta.get('user', '')
         self.working_dir = meta.get('workdir') or meta.get('working_dir', '')
         dns_search_meta = meta.get('dns_search', [])

--- a/lain_sdk/yaml/parser.py
+++ b/lain_sdk/yaml/parser.py
@@ -344,7 +344,7 @@ class Proc:
             cmd_list = meta_cmd.split()
         elif isinstance(meta_cmd, list) and all(isinstance(item, basestring) for item in meta_cmd):
             cmd_list = meta_cmd
-        else:   # None 或者非法输入，在 lain validate 里检查
+        else:   # None 或者非法输入，用 lain validate 里检查
             cmd_list = []
         return cmd_list
 

--- a/lain_sdk/yaml/parser.py
+++ b/lain_sdk/yaml/parser.py
@@ -13,6 +13,7 @@ from os.path import abspath
 from ..mydocker import gen_image_name
 from .conf import PRIVATE_REGISTRY, DOMAIN, DOCKER_APP_ROOT
 from ..util import lain_based_path
+from ..util import info
 
 SOCKET_TYPES = 'tcp udp'
 SocketType = Enum('SocketType', SOCKET_TYPES)
@@ -169,6 +170,7 @@ class Proc:
             self.type = ProcType[proc_info[0]]  ## 放弃meta里面的type定义
         self.image = meta.get('image', default_image_name)
         meta_cmd = meta.get('cmd')
+        info("kai >>> meta_cmd: {}".format(meta_cmd))
         self.cmd = meta_cmd if meta_cmd else ''
         self.user = meta.get('user', '')
         self.working_dir = meta.get('workdir') or meta.get('working_dir', '')

--- a/lain_sdk/yaml/parser.py
+++ b/lain_sdk/yaml/parser.py
@@ -346,7 +346,7 @@ class Proc:
             command_and_params_list = command_and_params.split()
         elif isinstance(command_and_params, list) and all(isinstance(item, basestring) for item in command_and_params):
             command_and_params_list = command_and_params
-        else:   # None 或者非法输入，用 lain validate 里检查
+        else:   # None 或者非法输入，如果是非法输入，在 lain build 时会给出警告
             command_and_params_list = []
         return command_and_params_list
 

--- a/lain_sdk/yaml/parser.py
+++ b/lain_sdk/yaml/parser.py
@@ -13,7 +13,6 @@ from os.path import abspath
 from ..mydocker import gen_image_name
 from .conf import PRIVATE_REGISTRY, DOMAIN, DOCKER_APP_ROOT
 from ..util import lain_based_path
-from ..util import info
 
 SOCKET_TYPES = 'tcp udp'
 SocketType = Enum('SocketType', SOCKET_TYPES)

--- a/lain_sdk/yaml/validator/schema.py
+++ b/lain_sdk/yaml/validator/schema.py
@@ -294,7 +294,7 @@ schema = {
             "type": "object",
             "properties": typed_proc_properties,
             "additionalProperties": False,
-            "oneOf": [
+            "anyOf": [
                 {
                     "required": ["entrypoint"]
                 },

--- a/lain_sdk/yaml/validator/schema.py
+++ b/lain_sdk/yaml/validator/schema.py
@@ -60,6 +60,7 @@ cmd = {
     "description": "cmd format, support exec form and shell form similiar to CMD in Dockerfile",
     "type": "object",
     "oneOf": [
+        {"type": "null"},
         {"type": "string"},
         {
             "type": "array",

--- a/lain_sdk/yaml/validator/schema.py
+++ b/lain_sdk/yaml/validator/schema.py
@@ -56,8 +56,8 @@ persistent_dirs_item = {
     ]
 }
 
-cmd = {
-    "description": "cmd format, support exec form and shell form similar to CMD in Dockerfile",
+exec_form_or_shell_form = {
+    "description": "exec form or shell form similar to the one in Dockerfile",
     "oneOf": [
         {"type": "null"},
         {"type": "string"},
@@ -71,7 +71,8 @@ cmd = {
 typed_proc_properties = {
     "user": {"type": "string"},
     "image": {"type": "string"},
-    "cmd": cmd,
+    "entrypoint": exec_form_or_shell_form,
+    "cmd": exec_form_or_shell_form,
     "workdir": {"type": "string"},
     "working_dir": {"type": "string"},
     "num_instances": {"type": "integer"},

--- a/lain_sdk/yaml/validator/schema.py
+++ b/lain_sdk/yaml/validator/schema.py
@@ -57,7 +57,7 @@ persistent_dirs_item = {
 }
 
 cmd = {
-    "description": "cmd format, support exec form and shell form similiar to CMD in Dockerfile",
+    "description": "cmd format, support exec form and shell form similar to CMD in Dockerfile",
     "oneOf": [
         {"type": "null"},
         {"type": "string"},
@@ -65,12 +65,7 @@ cmd = {
             "type": "array",
             "items": {"type": "string"}
         }
-    ],
-    "message": 'Your *cmd* setup is not correct.\
-    cmd supports 3 forms similar to Dockerfile\'s CMD:\
-    1. cmd: ["excutable", "param1", "param2"]   # exec form\
-    2. cmd: ["param1", "param2"]    # as default parameters to ENTRYPOINT\
-    3. cmd: excutable param1 param2     # shell form'
+    ]
 }
 
 typed_proc_properties = {

--- a/lain_sdk/yaml/validator/schema.py
+++ b/lain_sdk/yaml/validator/schema.py
@@ -294,6 +294,14 @@ schema = {
             "type": "object",
             "properties": typed_proc_properties,
             "additionalProperties": False,
+            "oneOf": [
+                {
+                    "required": "entrypoint"
+                },
+                {
+                    "required": "cmd"
+                }
+            ]
         },
         portal_proc_pattern: {
             "type": "object",

--- a/lain_sdk/yaml/validator/schema.py
+++ b/lain_sdk/yaml/validator/schema.py
@@ -56,10 +56,22 @@ persistent_dirs_item = {
     ]
 }
 
+cmd = {
+    "description": "cmd format, support exec form and shell form similiar to CMD in Dockerfile",
+    "type": "object",
+    "oneOf": [
+        {"type": "string"},
+        {
+            "type": "array",
+            "items": {"type": "string"}
+        }
+    ]
+}
+
 typed_proc_properties = {
     "user": {"type": "string"},
     "image": {"type": "string"},
-    "cmd": {"type": "string"},
+    "cmd": cmd,
     "workdir": {"type": "string"},
     "working_dir": {"type": "string"},
     "num_instances": {"type": "integer"},

--- a/lain_sdk/yaml/validator/schema.py
+++ b/lain_sdk/yaml/validator/schema.py
@@ -65,7 +65,12 @@ cmd = {
             "type": "array",
             "items": {"type": "string"}
         }
-    ]
+    ],
+    "message": 'Your *cmd* setup is not correct.\
+    cmd supports 3 forms similar to Dockerfile\'s CMD:\
+    1. cmd: ["excutable", "param1", "param2"]   # exec form\
+    2. cmd: ["param1", "param2"]    # as default parameters to ENTRYPOINT\
+    3. cmd: excutable param1 param2     # shell form'
 }
 
 typed_proc_properties = {

--- a/lain_sdk/yaml/validator/schema.py
+++ b/lain_sdk/yaml/validator/schema.py
@@ -296,10 +296,10 @@ schema = {
             "additionalProperties": False,
             "oneOf": [
                 {
-                    "required": "entrypoint"
+                    "required": ["entrypoint"]
                 },
                 {
-                    "required": "cmd"
+                    "required": ["cmd"]
                 }
             ]
         },

--- a/lain_sdk/yaml/validator/schema.py
+++ b/lain_sdk/yaml/validator/schema.py
@@ -58,7 +58,6 @@ persistent_dirs_item = {
 
 cmd = {
     "description": "cmd format, support exec form and shell form similiar to CMD in Dockerfile",
-    "type": "object",
     "oneOf": [
         {"type": "null"},
         {"type": "string"},


### PR DESCRIPTION
# 令 `proc.cmd` 支持类似于 `Dockerfile` 的 `exec form` 和 `shell form`，并支持 `proc.entrypoint`

## 这个更改令 `proc.cmd` 支持类似于 `Dockerfile` `CMD` 的三种形式:

- `cmd: ["executable","param1","param2"]` (exec form)
- `cmd: ["param1","param2"]` (as default parameters to ENTRYPOINT)
- `cmd: command param1 param2` (shell form)

## 这个更改使得 `proc.entrypoint` 得到支持，并可以使用 `exec form` 和 `shell form` 两种形式：

- `entrypoint: ["executable","param1","param2"]` (exec form)
- `entrypoint: command param1 param2` (shell form)

## 测试

### 测试目标

- `lain build` 成功
- `lain run web` 成功
- `lain tag local && lain push local && lain deploy local` 成功（原来 deploy 没有问题）
- `lain validate` 成功

### 测试用例

#### 没有 ENTRYPOINT 时（[https://github.com/kaizhang-shanxi/go-blog-on-lain](https://github.com/kaizhang-shanxi/go-blog-on-lain)）：
- `web` 里不写 `cmd`，即 `cmd` 为空
- 写了 `cmd`，但值为空格
- `cmd: /lain/app/blog/blog`
- `cmd: /lain/app/blog/blog -http=:8080`
- `cmd: []`
- `cmd: ["/lain/app/blog/blog"]`
- `cmd: ["/lain/app/blog/blog", "-http=:8080"]`
- `cmd: ["/lain/app/blog/blog", "-http", ":8080"]`

#### 有 ENTRYPOINT 时（[https://github.com/kaizhang-shanxi/go-blog-on-lain/tree/with-entrypoint](https://github.com/kaizhang-shanxi/go-blog-on-lain/tree/with-entrypoint)）：

- `web` 里不写 `cmd`，即 `cmd` 为空
- 写了 `cmd`，但值为空格
- `cmd: param1`
- `cmd: param1 param2`
- `cmd: []`
- `cmd: ["param1"]`
- `cmd: ["param1", "param2"]`

## 重要

**需要同时修改 [console](https://github.com/laincloud/console/pull/6)**