### PR TITLE
support macOS

### DIFF
--- a/lain_sdk/__init__.py
+++ b/lain_sdk/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = '2.2.1'
+__version__ = '2.2.2'

--- a/lain_sdk/mydocker.py
+++ b/lain_sdk/mydocker.py
@@ -21,7 +21,7 @@ DOCKER_BASE_URL = os.environ.get('DOCKER_HOST', '')
 # docker_reg set through param or env LAIN_DOCKER_REGISTRY
 
 
-def _docker(args, cwd=None, env={}, capture_output=False, print_stdout=True):
+def _docker(args, cwd=None, env=os.environ, capture_output=False, print_stdout=True):
     """
     Wrapper of Docker client. Use subprocess instead of docker-py to
     avoid API version inconsistency problems.
@@ -49,7 +49,7 @@ def _docker(args, cwd=None, env={}, capture_output=False, print_stdout=True):
         return output
     else:
         retcode = subprocess.call(cmd, env=env, cwd=cwd, stderr=subprocess.STDOUT,
-                stdout=(None if print_stdout else open('/dev/null', 'w')))
+                                  stdout=(None if print_stdout else open('/dev/null', 'w')))
         return retcode
 
 


### PR DESCRIPTION
在 macOS 上，使用 subprocess 调用 docker 命令时，如果指定 env 为空字典时，会有问题：

```
Traceback (most recent call last):
  File "/Users/bibaijin/Projects/lain-cli/lain_cli/lain.py", line 73, in <module>
    main()
  File "/Users/bibaijin/Projects/lain-cli/lain_cli/lain.py", line 69, in main
    parser.dispatch()
  File "/usr/local/lib/python2.7/site-packages/argh/helpers.py", line 55, in dispatch
    return dispatch(self, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/argh/dispatching.py", line 174, in dispatch
    for line in lines:
  File "/usr/local/lib/python2.7/site-packages/argh/dispatching.py", line 277, in _execute_command
    for line in result:
  File "/usr/local/lib/python2.7/site-packages/argh/dispatching.py", line 260, in _call
    result = function(*positional, **keywords)
  File "/usr/local/lib/python2.7/site-packages/lain_cli/build.py", line 20, in build
    yml = lain_yaml()
  File "/usr/local/lib/python2.7/site-packages/lain_cli/utils.py", line 57, in lain_yaml
    return LainYaml(LAIN_YAML_PATH, ignore_prepare=ignore_prepare)
  File "/Users/bibaijin/Projects/lain-sdk/lain_sdk/lain_yaml.py", line 37, in __init__
    self.init_act(self.yaml_path, ignore_prepare=ignore_prepare)
  File "/Users/bibaijin/Projects/lain-sdk/lain_sdk/lain_yaml.py", line 50, in init_act
    self._prepare_act(ignore_prepare=ignore_prepare)
  File "/Users/bibaijin/Projects/lain-sdk/lain_sdk/lain_yaml.py", line 371, in _prepare_act
    shared_prepare_image_name = self.ensure_proper_shared_image()
  File "/Users/bibaijin/Projects/lain-sdk/lain_sdk/lain_yaml.py", line 125, in ensure_proper_shared_image
    if mydocker.pull(remote_latest[1]) != 0:
  File "/Users/bibaijin/Projects/lain-sdk/lain_sdk/mydocker.py", line 266, in pull
    retcode = _docker(['pull', name])
  File "/Users/bibaijin/Projects/lain-sdk/lain_sdk/mydocker.py", line 50, in _docker
    stdout=(None if print_stdout else open('/dev/null', 'w')))
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 168, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 390, in __init__
    errread, errwrite)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1024, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

所以改为了继承当前的环境变量。