### PR TITLE
fix bug when copy release on mac

### DIFF
--- a/lain_sdk/__init__.py
+++ b/lain_sdk/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = '2.2.2'
+__version__ = '2.2.3'

--- a/lain_sdk/mydocker.py
+++ b/lain_sdk/mydocker.py
@@ -153,7 +153,7 @@ def copy_to_host(image_name, docker_path, host_path, directory=False):
         cp = ['cp', '-r']
     else:
         cp = ['cp']
-    inter_host_dir = tempfile.mkdtemp()
+    inter_host_dir = tempfile.mkdtemp(dir='/tmp', prefix='lain-sdk-')
     inter_dock_dir = '/lain_share'
     docker_args = ['run', '--rm', '-v', '{}:{}'.format(inter_host_dir, inter_dock_dir), image_name]
     docker_args += cp + [docker_path, inter_dock_dir]


### PR DESCRIPTION
`lain build` 时，在 mac 上会出现错误：

```
docker: Error response from daemon: Mounts denied: s/#namespaces for more info.
.
/lr793hrj0vq4fb8pplcp23l40000gp/T/tmpfQ5YEj
is not shared from OS X and is not known to Docker.
You can configure shared paths from Docker -> Preferences... -> File Sharing.
See https://docs.docker.com/docker-for-mac/osxf.
ERRO[0000] error getting events from daemon: net/http: request canceled
>>> IOError(2, 'No such file or directory')
```

这是因为 mac 上的 docker 默认没有共享 /var 文件夹，而 lain-sdk 使用 /var 文件夹作为缓存复制文件，所以改为了 `/tmp` 文件夹。