### PR TITLE
add meta version when lain build

### DIFF
--- a/lain_sdk/__init__.py
+++ b/lain_sdk/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = '2.2.2'
+__version__ = '2.3.0'

--- a/lain_sdk/lain_yaml.py
+++ b/lain_sdk/lain_yaml.py
@@ -360,7 +360,7 @@ class LainYaml(object):
 
         self.ignore = ['.git', '.vagrant']
 
-        self.gen_name = partial(mydocker.gen_image_name, appname=self.appname)
+        self.gen_name = partial(mydocker.gen_image_name, appname=self.appname, meta_version=meta_version(self.ctx))
 
         phases = ('prepare', 'build', 'release', 'test', 'meta')
         self.img_names = {phase: self.gen_name(
@@ -398,7 +398,6 @@ class LainYaml(object):
         return meta_version(self.ctx, sha1)
 
     def tag_meta_version(self, name, sha1=''):
-        tagged = '%s/%s-%s' % (PRIVATE_REGISTRY, name,
-                               meta_version(self.ctx, sha1))
+        tagged = '%s/%s' % (PRIVATE_REGISTRY, name)
         mydocker.tag(name, tagged)
         return tagged


### PR DESCRIPTION
在同一台机器上对同一个 LAIN 应用的不同分支进行 `lain build` 时，两个分支产生的镜像均为 ${appname}:build、 ${appname}:meta、 ${appname}:release，相互之间会覆盖，引起之后的 `lain tag` 的混淆，所以在 `lain build` 时加了 meta version，即 ${git-commit-timestamp}-${git-commit-id}。 

> - 比如在 Jenkins 上会存在上述场景。
> - 与 [lain-cli 的这个 PR](https://github.com/laincloud/lain-cli/pull/17) 一起更改。