### PR TITLE
use docker instead of docker-py

### DIFF
--- a/lain_sdk/__init__.py
+++ b/lain_sdk/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = '2.3.1'
+__version__ = '2.3.2'

--- a/lain_sdk/mydocker.py
+++ b/lain_sdk/mydocker.py
@@ -6,7 +6,7 @@ import shutil
 import tempfile
 import requests
 import subprocess
-from docker import Client
+import docker
 from jinja2 import Template
 from .util import (info, error,
                    recur_create_file, rm,
@@ -326,10 +326,10 @@ def get_tag_list_in_registry(registry, appname):
 
 def get_tag_list_in_docker_daemon(registry, appname):
     tag_list = []
-    c = Client()
-    imgs = c.images()
+    c = docker.from_env()
+    imgs = c.images.list()
     for img in imgs:
-        repo_tags = img['RepoTags']
+        repo_tags = img.tags
         if not repo_tags:
             continue
         for repo_tag in repo_tags:
@@ -346,10 +346,10 @@ def get_tag_list_in_docker_daemon(registry, appname):
 
 def get_tag_list_using_by_containers(registry, appname):
     tag_list = []
-    c = Client()
-    containers = c.containers()
+    c = docker.from_env()
+    containers = c.containers.list()
     for container in containers:
-        repo, tag = container['Image'].split(":")
+        repo, tag = container.attrs['Config']['Image'].split(":")
         if repo == "%s/%s" % (registry, appname) and tag not in tag_list:
             tag_list.append(tag)
     return tag_list

--- a/lain_sdk/util.py
+++ b/lain_sdk/util.py
@@ -147,10 +147,9 @@ def _get_registry_auth_url(response):
 def get_jwt_for_registry(auth_url, registry, appname):
     # get auth username and password from dockercfg
     try:
-        cfgs = auth.load_config()
-        cfg = cfgs[registry]
-        username = cfg['username']
-        password = cfg['password']
+        cfg = auth.resolve_authconfig(auth.load_config(), registry=registry)
+        username = cfg['username'] if 'username' in cfg else cfg['Username']
+        password = cfg['password'] if 'password' in cfg else cfg['Password']
         # phase, phase_config = get_phase_config_from_registry(registry)
         # domain = phase_config.get(user_config.domain_key, '')
         # only use `lain.local` as service

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
     'requests==2.6.0',
     'six==1.9.0',
     'websocket-client==0.32.0',
-    'docker-py==1.7.2',
+    'docker==2.3.0',
     'pytest==2.7.0',
     'pytest-random==0.2',
     'pytest-cov==1.8.1',


### PR DESCRIPTION
## 起因

假如用户在 macOS 上使用 lain-cli，且进行过 `docker login ${registry}` 的操作，则会发生[这个错误](https://github.com/laincloud/lain-cli/issues/25)。

## 经过

原因是 lain-sdk 依赖的docker-py==1.7.2 较老，不能解析 ${HOME}/.docker/config.json 文件，所以将 docker-py 替换成了 docker 官方 SDK(docker==2.3.0)。

## 结果

### macOS

- `lain build` 成功。而 `lain build` 会调用 `get_tag_list_in_docker_daemon`，说明这个函数工作正常
- `lain rmi dev` 成功。而 `lain rmi dev` 会调用 `get_tag_list_using_by_containers`，说明这个函数工作正常
- 我打开了 `registry.lain.test` 的 auth，然后 `lain config save-global private_docker_registry registry.lain.test`，接着 `lain build`，成功。这时 `lain build` 会调用 `get_jwt_for_registry`，说明这个函数工作正常

### Linux

为了保证兼容性，我在 Linux 上也做了同样的测试：
- `lain build` 成功。而 `lain build` 会调用 `get_tag_list_in_docker_daemon`，说明这个函数工作正常
- `lain rmi dev` 成功。而 `lain rmi dev` 会调用 `get_tag_list_using_by_containers`，说明这个函数工作正常
- 我打开了 `registry.lain.test` 的 auth，然后 `lain config save-global private_docker_registry registry.lain.test`，接着 `lain build`，成功。这时 `lain build` 会调用 `get_jwt_for_registry`，说明这个函数工作正常