### PR TITLE
respect ENTRYPOINT and CMD in Dockerfile

### DIFF
--- a/lain_sdk/__init__.py
+++ b/lain_sdk/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = '2.3.5'
+__version__ = '2.3.6'


### PR DESCRIPTION
原来的逻辑：
- lain.yaml 里的 entrypoint 或 cmd 如果为空，则运行容器时 entrypoint 或 cmd 也为空，而不会考虑基底镜像 Dockerfile 里的 ENTRYPOINT 和 CMD

现在的逻辑：
- 基底镜像 Dockerfile 里的 ENTRYPOINT 和 CMD 是默认值，如果 lain.yaml 里配置了 entrypoint 或 cmd，则覆盖对应配置

更改后的逻辑更自然，也与 docker 的运行逻辑一致。